### PR TITLE
Forces pyqt to version 4

### DIFF
--- a/installers/osx/pygobstones.install.sh
+++ b/installers/osx/pygobstones.install.sh
@@ -11,7 +11,7 @@ DEST_DIR=~/pygobstones
 echo "[PyGobstones] PyGobstones $PYGOBSTONES_VERSION installation started."
 echo "[PyGobstones] Installing dependencies"
 /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-brew install pyqt
+brew install cartr/qt4/pyqt
 brew install wget
 
 echo "[PyGobstones] Downloading PyGobstones files"


### PR DESCRIPTION
brew install pyqt esta instalando la version 5 de PyQt y al ejecutar pygobstones busca la version 4, por lo tanto muestra el error "No module named PyQt4". El cambio realizado fuerza la instalación de la version 4.